### PR TITLE
Change visibility for for `parseMimeType` to public.

### DIFF
--- a/src/Bitworking/Mimeparse.php
+++ b/src/Bitworking/Mimeparse.php
@@ -29,7 +29,7 @@ class Mimeparse
      * @return array ($type, $subtype, $params)
      * @throws UnexpectedValueException when $mimeType does not include a valid subtype
      */
-    protected static function parseMimeType($mimeType)
+    public static function parseMimeType($mimeType)
     {
         $parts = explode(';', $mimeType);
 


### PR DESCRIPTION
This method is rather useful when parsing incoming MIME types, currently it can't be used unless `Mimeparse` is subclassed.
